### PR TITLE
Change some schema constraints and add coins attribute to users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ next-env.d.ts
 
 # database
 /pg-data
+/drizzle

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -13,4 +13,5 @@ export default {
   out: "./drizzle",
   driver: "pg",
   dbCredentials: { connectionString: process.env.POSTGRES_URL },
+  verbose: true,
 } satisfies Config;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -19,6 +19,7 @@ export const usersTable = pgTable(
     username: varchar("username", { length: 80 }).notNull(),
     hashedPassword: varchar("hashedpassword", { length: 255 }).notNull(),
     avatarUrl: text("avatarurl"),
+    coins: integer("coins").notNull().default(0),
   },
   (table) => ({
     userIdIndex: index("userIdIndex").on(table.userId),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -18,7 +18,7 @@ export const usersTable = pgTable(
     ntuEmail: varchar("ntuemail", { length: 63 }).notNull().unique(),
     username: varchar("username", { length: 80 }).notNull(),
     hashedPassword: varchar("hashedpassword", { length: 255 }).notNull(),
-    avatarUrl: varchar("avatarurl"),
+    avatarUrl: text("avatarurl"),
   },
   (table) => ({
     userIdIndex: index("userIdIndex").on(table.userId),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -14,7 +14,7 @@ import {
 export const usersTable = pgTable(
   "users",
   {
-    userId: uuid("userid").defaultRandom().notNull().unique(),
+    userId: uuid("userid").primaryKey().defaultRandom(),
     ntuEmail: varchar("ntuemail", { length: 63 }).notNull().unique(),
     username: varchar("username", { length: 80 }).notNull(),
     hashedPassword: varchar("hashedpassword", { length: 255 }).notNull(),


### PR DESCRIPTION
- Changed schema constraints:
  1. userId: unique and not null -> primary key
  2. avatarUrl: varchar -> text 

- Added coins to users attribute. I added (CHECK coins >= 0) constraint via pgAdmin; Drizzle does not support this constraint and thus it is not reflected in the Drizzle schema.